### PR TITLE
Bump up probeinterface version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dynamic = ["version"]
 dependencies = [
     'aind-data-transformation>=0.0.18',
     'spikeinterface[full]>=0.102.0',
-    'probeinterface>=0.2.24',
+    'probeinterface>=0.2.26',
     'wavpack-numcodecs>=0.2.2',
 ]
 


### PR DESCRIPTION
@jtyoung84 

We need a new version of probeinterface in prod to correctly parse a new probe type that some folks have started using recently (Neuropixels 2.0 - Quad Base). Can you update prod with this new version?