### PR TITLE
Bump up probeinterface to 0.2.28

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dynamic = ["version"]
 dependencies = [
     'aind-data-transformation>=0.0.18',
     'spikeinterface[full]>=0.102.0',
-    'probeinterface>=0.2.26',
+    'probeinterface>=0.2.28',
     'wavpack-numcodecs>=0.2.2',
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dynamic = ["version"]
 dependencies = [
     'aind-data-transformation>=0.0.18',
     'spikeinterface[full]>=0.102.0',
-    'probeinterface>=0.2.24',
+    'probeinterface>=0.2.26',
     'wavpack-numcodecs>=0.2.2',
 ]
 


### PR DESCRIPTION
@yonibrowning @jsiegle 

The most recent release of probeinterface should support the new version of Open Ephys settings files for the Quad Base probe with one NP_PROBE entry per shank.

@jtyoung84 can you deploy this in prod so that Yoni can try some Quad Base uploads?