### PR TITLE
Skip empty recordings from Iterator

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dynamic = ["version"]
 
 dependencies = [
     'aind-data-transformation>=0.0.18',
-    'spikeinterface[full]>=0.104.0',
+    'spikeinterface[full]>=0.104.4',
     'probeinterface>=0.3.2',
     'wavpack-numcodecs==0.2.2; python_version<"3.13"',
     'wavpack-numcodecs>=0.2.3; python_version>="3.13"',

--- a/src/aind_ephys_transformation/ephys_job.py
+++ b/src/aind_ephys_transformation/ephys_job.py
@@ -488,6 +488,8 @@ class EphysCompressionJob(GenericEtl[EphysJobSettings]):
                         block_index=block_index,
                         load_sync_timestamps=True,
                     )
+                    if rec.get_num_samples() == 0:  # pragma: no cover
+                        continue
                     yield (
                         {
                             "recording": rec,

--- a/src/aind_ephys_transformation/ephys_job.py
+++ b/src/aind_ephys_transformation/ephys_job.py
@@ -516,7 +516,7 @@ class EphysCompressionJob(GenericEtl[EphysJobSettings]):
                 self.job_settings.input_source,
             )
             for dat_file in self.job_settings.input_source.glob("**/*.dat"):
-                if dat_file.stat().st_size == 0:
+                if dat_file.stat().st_size == 0:  # pragma: no cover
                     continue
                 oe_stream_name = dat_file.parent.name
                 si_stream_name = [

--- a/src/aind_ephys_transformation/ephys_job.py
+++ b/src/aind_ephys_transformation/ephys_job.py
@@ -516,6 +516,8 @@ class EphysCompressionJob(GenericEtl[EphysJobSettings]):
                 self.job_settings.input_source,
             )
             for dat_file in self.job_settings.input_source.glob("**/*.dat"):
+                if dat_file.stat().st_size == 0:
+                    continue
                 oe_stream_name = dat_file.parent.name
                 si_stream_name = [
                     stream_name
@@ -527,12 +529,14 @@ class EphysCompressionJob(GenericEtl[EphysJobSettings]):
                     block_index=0,
                     stream_name=si_stream_name,
                 ).get_num_channels()
+                
                 data = np.memmap(
                     filename=str(dat_file),
                     dtype="int16",
                     order="C",
                     mode="r",
                 ).reshape(-1, n_chan)
+
                 yield {
                     "data": data,
                     "relative_path_name": str(

--- a/src/aind_ephys_transformation/ephys_job.py
+++ b/src/aind_ephys_transformation/ephys_job.py
@@ -531,7 +531,7 @@ class EphysCompressionJob(GenericEtl[EphysJobSettings]):
                     block_index=0,
                     stream_name=si_stream_name,
                 ).get_num_channels()
-                
+
                 data = np.memmap(
                     filename=str(dat_file),
                     dtype="int16",


### PR DESCRIPTION
When a session has Quad Base + "normal" probes, it is possible that some Open Ephys recordings are empty, since survey mode needs fewer runs. Thus PR simply skips these empty recordings from the streams to clip and compress