### PR TITLE
Bump up neo to 0.14.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     'aind-data-transformation>=0.0.18',
     'spikeinterface[full]>=0.104.4',
     'probeinterface>=0.3.2',
+    'neo>=0.14.5',
     'wavpack-numcodecs==0.2.2; python_version<"3.13"',
     'wavpack-numcodecs>=0.2.3; python_version>="3.13"',
     's3fs',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dynamic = ["version"]
 
 dependencies = [
     'aind-data-transformation>=0.0.18',
-    'spikeinterface[full]>=0.104.4',
+    'spikeinterface[full]>=0.104.6',
     'probeinterface>=0.3.2',
     'neo>=0.14.5',
     'wavpack-numcodecs==0.2.2; python_version<"3.13"',


### PR DESCRIPTION
@jtyoung84 this simply bumps up the NEO version to the most recent relese, which fixes some issues that @alakunina has related to empty streams

Could you deploy to the update service?